### PR TITLE
ゲームの初期進行状態の遷移の不具合を解消

### DIFF
--- a/django/trials/utils.py
+++ b/django/trials/utils.py
@@ -23,15 +23,15 @@ def update_trial_game_state(trial_id) -> None:
 
     game_state = GameState.objects.get(trial_id=trial_id)
 
-    trial = Trial.objects.get(id=trial_id)
-    if trial.defendant_claim and trial.plaintiff_claim:
-        game_state.state = "show_first_claim_and_judge"
-        game_state.save()
-        return
-
     plaintiff = Player.objects.filter(trial_id=trial_id, role="plaintiff").exists()
     defendant = Player.objects.filter(trial_id=trial_id, role="defendant").exists()
     if plaintiff and defendant:
         game_state.state = "show_one_qr_codes"
+        game_state.save()
+        return
+
+    trial = Trial.objects.get(id=trial_id)
+    if trial.defendant_claim and trial.plaintiff_claim:
+        game_state.state = "show_first_claim_and_judge"
         game_state.save()
         return


### PR DESCRIPTION
`show_two_qr_codes`-> `show_one_qr_codes` -> `show_first_claim_and_judge` -> ... と遷移したいのに、記述位置が逆転していることにより`show_one_qr_codes`を経ずに`show_first_claim_and_judge`に遷移していた問題を解決しました。